### PR TITLE
fix: segfault crash for `curl --help` due to commit 32ba44f434c42f072…

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -902,7 +902,7 @@ static void get_categories(void)
 void tool_help(const char *category)
 {
   /* Lets handle the string "category" differently to not print an errormsg */
-  if(curl_strequal(category, "category")) {
+  if(category && curl_strequal(category, "category")) {
     get_categories();
     return;
   }


### PR DESCRIPTION
…08f4583c3e8f33484563e6f (help: Fix misleading usage output)

Reason: curl_strequal b0rks on a NULL pointer for `category`.
